### PR TITLE
Fixed mapped device name for root device in create.

### DIFF
--- a/os/common.sh
+++ b/os/common.sh
@@ -60,3 +60,23 @@ parse_list_parameter()
 	eval $1+='("$local__x")'
     done
 }
+
+# Adapted from ganeti-instance-debootstrap.
+map_disk0() {
+  blockdev="$1"
+  filesystem_dev_base=`kpartx -l $blockdev | \
+		       grep -m 1 -- "p1 :[0-9 ]* $blockdev " | \
+		       awk '{print $1}'`
+  if [ -z "$filesystem_dev_base" ]; then
+    die "Cannot interpret kpartx output and get partition mapping"
+  fi
+  kpartx -a -s $blockdev > /dev/null
+  filesystem_dev="/dev/mapper/$filesystem_dev_base"
+  if [ ! -b "$filesystem_dev" ]; then
+    die "Can't find kpartx mapped partition: $filesystem_dev"
+  fi
+  echo "$filesystem_dev"
+}
+unmap_disk0() {
+  kpartx -d "$1"
+}

--- a/os/create
+++ b/os/create
@@ -28,11 +28,8 @@ qemu-img convert -f qcow2 -O raw "$IMAGE_DIR/$IMAGE_FILE" "$targetdev"
 rootmnt="`mktemp -d /tmp/ganeti-os-nocloud-root.XXXXXX`"
 atexit "rmdir $rootmnt"
 
-kpartx -a "$targetdev"
-atexit "kpartx -d $targetdev"
-
-mapperbase="/dev/mapper/`basename $targetdev`"
-rootdev="${mapperbase}p1"
+rootdev=`map_disk0 $targetdev`
+atexit "unmap_disk0 $targetdev"
 mount "$rootdev" "$rootmnt"
 atexit "umount $rootmnt"
 


### PR DESCRIPTION
This should fix the issue with the DM device name reported in #1 and #2.  Please test if you have time; I'll merge soon.  It is based on ganeti-instance-debootstrap and works on my end, though I don't have the more complex device names.  I prefer this one, as it's more picky about the kpartx output.