### PR TITLE
Support NIC_%N_NAME; use set-name to workaround cloud-init bug

### DIFF
--- a/os/create
+++ b/os/create
@@ -129,11 +129,16 @@ generate_network_config()
 	nic_network_subnet6=$(eval echo \$NIC_${i}_NETWORK_SUBNET6)
 	nic_gateway4=$(eval echo \$NIC_${i}_NETWORK_GATEWAY)
 	nic_gateway6=$(eval echo \$NIC_${i}_NETWORK_GATEWAY6)
-	echo             "  eth${i}:"
+	nic_name=$(eval echo \$NIC_${i}_NAME)
+	if [ -z "$nic_name"]; then
+	    nic_name="eth${i}"
+	fi
+	echo             "  ${nic_name}:"
 	if [ -n "$nic_mac" ]; then
 	    echo         "    match: {macaddress: '$nic_mac'}"
+	    echo         "    set-name: '$nic_name'"
 	else
-	    echo         "    match: {name: 'eth${i}'}"
+	    echo         "    match: {name: '$nic_name'}"
 	fi
 	if [ -z "$nic_network_subnet4" ]; then
 	    ipv4_prefixlen=24

--- a/os/create
+++ b/os/create
@@ -130,13 +130,17 @@ generate_network_config()
 	nic_gateway4=$(eval echo \$NIC_${i}_NETWORK_GATEWAY)
 	nic_gateway6=$(eval echo \$NIC_${i}_NETWORK_GATEWAY6)
 	nic_name=$(eval echo \$NIC_${i}_NAME)
+	nic_name_is_provided=true
 	if [ -z "$nic_name"]; then
 	    nic_name="eth${i}"
+	    nic_name_is_provided=false
 	fi
 	echo             "  ${nic_name}:"
 	if [ -n "$nic_mac" ]; then
 	    echo         "    match: {macaddress: '$nic_mac'}"
-	    echo         "    set-name: '$nic_name'"
+	    if $nic_name_is_provided; then
+		echo         "    set-name: '$nic_name'"
+	    fi
 	else
 	    echo         "    match: {name: '$nic_name'}"
 	fi


### PR DESCRIPTION
This proposed patch does two things:
* if user supplies a NIC "name", then use it instead of auto-generated `eth0`, `eth1` etc
* when matching MAC address, add a "set-name:" key.  This is a workaround for [LP:1979877](https://bugs.launchpad.net/cloud-init/+bug/1979877)

Further discussion at https://groups.google.com/g/ganeti/c/pTw66TZ5gPQ