### PR TITLE
Add support for images where root patition is not the first partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The variant configuration supports the following variables:
     `qcow2`.
   - `IMAGE_DIR` is the directory where to look for images, by default
     `/var/cache/ganeti-cloudimg`.
+  - `IMAGE_ROOTFS_PARTNO` is the partition number of the root filesystem
+     in the image. Used when adding cloud config.
 
 Next, put your [cloud config data][cloud-config] under
 `/etc/ganeti/nocloud/user-data/`.  The OS creation script will look for

--- a/os/common.sh
+++ b/os/common.sh
@@ -66,7 +66,7 @@ parse_list_parameter()
 map_disk0() {
   blockdev="$1"
   filesystem_dev_base=`kpartx -l $blockdev | \
-		       grep -m 1 -- "p1 :[0-9 ]* $blockdev " | \
+		       grep -m 1 -- "p${IMAGE_ROOTFS_PARTNO:-1} :[0-9 ]* $blockdev " | \
 		       awk '{print $1}'`
   if [ -z "$filesystem_dev_base" ]; then
     die "Cannot interpret kpartx output and get partition mapping"

--- a/os/variants/rocky-9.conf
+++ b/os/variants/rocky-9.conf
@@ -1,0 +1,2 @@
+IMAGE_FILE=Rocky-9-GenericCloud-Base-latest.x86_64.qcow2
+IMAGE_ROOTFS_PARTNO=4


### PR DESCRIPTION
For Rocky images the root filesystem is not partition 1. The `IMAGE_ROOTFS_PARTNO` variable in the variants configuration file, provides a way to specify which partition the cloud config configuration should be written to.